### PR TITLE
10th September 2018: Hotfix #3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               eb init Rendeer -r ap-southeast-1 -p "arn:aws:elasticbeanstalk:ap-southeast-1::platform/Docker running on 64bit Amazon Linux/2.12.2"
-              eb deploy
+              eb deploy --timeout 30
             fi
 
 workflows:

--- a/src/main.js
+++ b/src/main.js
@@ -63,10 +63,12 @@ const fetchContent = async (pageURL) => {
     // Ensure that only whitelisted URLs and GET method is allowed
     if (!whitelistRegExp.test(url) || method.toLowerCase() !== 'get' || /^(font|media|websocket|manifest)$/i.test(resourceType)) {
       request.abort();
+    /* Puppeteer 1.8.0 breaks this
     } else if (resourceType.toLowerCase() === 'image') {
       request.continue({
         url: 'data:image/gif;base64,R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=',
       });
+    */
     } else {
       request.continue();
     }
@@ -263,7 +265,7 @@ require('http').createServer(async (req, res) => {
     res.end(`Oops. Something is wrong.\n\n${message}`);
 
     // Handle websocket not opened error
-    if (/not opened/i.test(message) && browser) {
+    if (/not open/i.test(message) && browser) {
       console.error('Web socket failed');
       try {
         // Sometimes it tries to close an already closed browser


### PR DESCRIPTION
- It seems Puppeteer 1.8.0 breaks `resourceType.toLowerCase() === 'image'` check
- Puppeteer 1.8.0 changes "WebSocket is not open" from "WebSocket is not open"